### PR TITLE
[feat] 메인 포스터 재사용 로직 수정

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -2,9 +2,11 @@
 // import { useState, useEffect } from 'react';
 // import axios from 'axios';
 import * as S from './page.styled';
+import { ThemeProvider } from 'styled-components';
 import MoovDa from '@/assets/moovdaLogo.svg';
 import MainCarousel from '@/components/MainCarousel/MainCarousel';
 import { MainPoster } from '@/components/MainPoster/MainPoster';
+import theme from '@/components/MainPoster/theme';
 
 export default function MainPage() {
   // const [data, setData] = useState([]);
@@ -54,7 +56,9 @@ export default function MainPage() {
   // },[]);
 
   const posters = data.map((poster, index) => (
-    <MainPoster key={index} data={poster} isWatched={false} isToWatch={false} /> //key는 movie-id로 변경
+    <ThemeProvider theme={theme.mainPage}>
+    <MainPoster key={index} data={poster} isWatched={false} isToWatch={false} />
+    </ThemeProvider>
   ));
   return (
     <S.Container>

--- a/client/src/components/MainPoster/MainPoster.styled.ts
+++ b/client/src/components/MainPoster/MainPoster.styled.ts
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 export const Container = styled.div<{ width?: string }>`
   display: flex;
   flex-direction: column;
-  width: ${(props) => props.width || '250px'};
+  width: ${(props) => props.theme.width};
   height: auto;
   gap: 5px;
   cursor: pointer;
@@ -17,20 +17,18 @@ export const PosterImg = styled.img`
   border-radius: 20px;
 `;
 
-export const Title = styled.div`
+export const Title = styled.div<{posterTitleGap?:string}>`
   display: flex;
   justify-content: center;
-  font-size: 20px;
-  margin-top: 10px;
-  margin-top: 30px;
+  margin-top: ${(props) => props.theme.posterTitleGap};
 `;
-export const TitleText = styled.div<{ 'font-size'?: string }>`
+export const TitleText = styled.div<{ titleFonSize?: string, maxWidth?:string }>`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  max-width: 230px;
+  max-width: ${(props) => props.theme.maxWidth};
   color: #e2e2e2;
-  font-size: ${(props) => props['font-size'] || '20px'};
+  font-size: ${(props) => props.theme.titleFontSize};
 `;
 export const Star = styled.div`
   display: flex;
@@ -38,7 +36,7 @@ export const Star = styled.div`
 `;
 
 export const Delete = styled.div`
-  position: absolute;
-  left: 220px;
-  top: 10px;
+position: absolute;
+margin-left:120px;
+margin-top:10px;
 `;

--- a/client/src/components/MainPoster/MainPoster.tsx
+++ b/client/src/components/MainPoster/MainPoster.tsx
@@ -10,7 +10,7 @@ interface Props {
   data: {
     poster: string;
     title: string;
-    star: number;
+    star?: number;
   };
   isWatched: boolean;
   isToWatch: boolean;

--- a/client/src/components/MainPoster/theme.ts
+++ b/client/src/components/MainPoster/theme.ts
@@ -1,0 +1,10 @@
+const theme={
+    //어느 페이지에서 사용할 것인지 구분하는 명칭 작성(페이지 이름을 권장합니다!)
+    mainPage:{
+        width:'250px',
+        titleFontSize:'20px',
+        posterTitleGap:'30px',
+        maxWidth:'230px',
+    },
+};
+export default theme;


### PR DESCRIPTION
###  Key Changes

---

- styled-components의 ThemeProvider을 활용하여 유연하게 컴포넌트 재활용이 가능하도록 하였습니다.
- 메인 포스터 컴포넌트 재활용에 대한 간단한 설명도 첨부합니다. https://www.notion.so/codestates/bfb9adc9483945dc8a0397c550537c41?pvs=4

